### PR TITLE
Support spellchecking in text editor (fixes #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "@jupyterlab/codemirror": "^0.19.1",
     "@jupyterlab/notebook": "^0.19.1",
     "@types/codemirror": "0.0.56",
-    "typo-js": "^1.0.3"
+    "typo-js": "^1.0.3",
+    "@jupyterlab/fileeditor": "^0.19.1"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",


### PR DESCRIPTION
This workarounds #1 as well - so if you would like to merge both of my PRs, I would suggest merging this one in favour of #10. It works for markdown and plain text files. An example:

![Screenshot from 2019-04-20 16-32-44](https://user-images.githubusercontent.com/5832902/56459341-f8f53680-6389-11e9-809e-2a46a2d360fa.png)
