### PR TITLE
Add ignore action

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   "license": "BSD-3-Clause",
   "author": "Iain Barr",
   "files": [
+    "dictionaries/*{aff,dic}",
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "dictionaries/*{aff,dic}"
+    "schema/**/*.{json,}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -47,6 +48,7 @@
     "typescript": "^3.7.0"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,0 +1,24 @@
+{
+  "jupyter.lab.setting-icon": "spellcheck:spellcheck",
+  "jupyter.lab.setting-icon-label": "Spellchecker",
+  "title": "Spellchecker",
+  "description": "Spellchecker settings.",
+  "definitions": {
+    "ignore": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "properties": {
+    "ignore": {
+      "title": "Words to be ignored by the spellchecker",
+      "description": "Case-sensitive list of words to be ignored",
+      "$ref": "#/definitions/ignore",
+      "default": ["JupyterLab", "Jupyter"]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,17 @@
-import {
-    JupyterFrontEnd, JupyterFrontEndPlugin
-} from '@jupyterlab/application';
-
-import {
-    FileEditor,
-    IEditorTracker
-} from '@jupyterlab/fileeditor';
-
-import {
-    INotebookTracker
-} from '@jupyterlab/notebook';
-
-import {
-    LabIcon
-} from '@jupyterlab/ui-components';
-
-import {
-    ICommandPalette, InputDialog, ReactWidget
-} from '@jupyterlab/apputils';
-
-import {
-  Menu
-} from '@lumino/widgets';
-
-import '../style/index.css';
+import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { LabIcon } from '@jupyterlab/ui-components';
+import { ICommandPalette, InputDialog, ReactWidget } from '@jupyterlab/apputils';
+import { Menu } from '@lumino/widgets';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { IStatusBar, TextItem } from "@jupyterlab/statusbar";
+import { Cell } from "@jupyterlab/cells";
 
 import * as CodeMirror from 'codemirror';
 
-import { IStatusBar, TextItem } from "@jupyterlab/statusbar";
-
+import '../style/index.css';
 import spellcheckSvg from '../style/icons/ic-baseline-spellcheck.svg';
-import { Cell } from "@jupyterlab/cells";
 
 export const spellcheckIcon = new LabIcon({
     name: 'spellcheck:spellcheck',
@@ -40,8 +21,10 @@ export const spellcheckIcon = new LabIcon({
 declare function require(name:string): any;
 let Typo = require("typo-js");
 
-const CMD_TOGGLE = "spellchecker:toggle-check-spelling";
-const CMD_APPLY_SUGGESTION = "spellchecker:apply-suggestion";
+const CMD_APPLY_SUGGESTION = 'spellchecker:apply-suggestion';
+const CMD_IGNORE_WORD = 'spellchecker:ignore'
+const CMD_TOGGLE = 'spellchecker:toggle-check-spelling';
+const CMD_UPDATE_SUGGESTIONS = 'spellchecker:update-suggestions';
 
 const TEXT_SUGGESTIONS_AVAILABLE = 'Adjust spelling to'
 const TEXT_NO_SUGGESTIONS = 'No spellcheck suggestions'
@@ -113,6 +96,8 @@ class SpellChecker {
     language: ILanguage;
     rx_word_char: RegExp     = /[^-\[\]{}():\/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
     rx_non_word_char: RegExp =  /[-\[\]{}():\/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
+    ignored_tokens: Set<string> = new Set();
+    settings: ISettingRegistry.ISettings;
     accepted_types = [
         'text/plain',
         'text/x-ipythongfm',   // IPython GFM = GitHub Flavored Markdown, applies to all .md files
@@ -120,7 +105,7 @@ class SpellChecker {
 
     constructor(
       public app: JupyterFrontEnd, public tracker: INotebookTracker, public palette: ICommandPalette,
-      public editor_tracker: IEditorTracker, public status_bar: IStatusBar
+      public editor_tracker: IEditorTracker, public status_bar: IStatusBar, public setting_registry: ISettingRegistry
     ){
         this.language = languages[0];
         this.setup_button();
@@ -129,6 +114,28 @@ class SpellChecker {
         this.load_dictionary().catch(console.warn);
         this.tracker.activeCellChanged.connect(() => this.setup_cell_editor(this.tracker.activeCell));
         this.editor_tracker.widgetAdded.connect((sender, widget) => this.setup_file_editor(widget.content));
+        this.setup_settings()
+        this.setup_ignore_action()
+    }
+
+    setup_settings() {
+        Promise.all([this.setting_registry.load(extension.id), this.app.restored])
+          .then(([settings]) => {
+              this.update_settings(settings);
+              settings.changed.connect(() => {
+                  this.update_settings(settings);
+              });
+          })
+          .catch((reason: Error) => {
+              console.error(reason.message);
+          });
+    }
+
+    update_settings(settings: ISettingRegistry.ISettings) {
+        this.settings = settings;
+        let tokens = settings.get('ignore').composite as Array<string>;
+        this.ignored_tokens = new Set(tokens)
+        this.refresh_state()
     }
 
     setup_file_editor(file_editor: FileEditor): void {
@@ -232,7 +239,6 @@ class SpellChecker {
         this.suggestions_menu = new Menu({commands: this.app.commands});
         this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
         this.suggestions_menu.title.icon = spellcheckIcon.bindprops({ stylesheet: 'menuItem' });
-        let CMD_UPDATE_SUGGESTIONS = 'spellchecker:update-suggestions';
 
         // this command is not meant to be show - it is just menu trigger detection hack
         this.app.commands.addCommand(CMD_UPDATE_SUGGESTIONS, {
@@ -259,6 +265,32 @@ class SpellChecker {
             },
             label: args => args['name'] as string
         });
+    }
+
+    setup_ignore_action() {
+        this.app.commands.addCommand(CMD_IGNORE_WORD, {
+            execute: () => { this.ignore() },
+            label: 'Ignore'
+        });
+
+        this.app.contextMenu.addItem({
+            selector: '.cm-spell-error',
+            command: CMD_IGNORE_WORD
+        });
+    }
+
+    ignore() {
+        let context = this.get_contextmenu_context();
+
+        if (context === null) {
+          console.log('Could not ignore the word as the context was no longer available')
+        } else {
+            let word = this.get_current_word(context);
+            this.settings.set(
+              'ignore',
+              [word.text.trim(), ...(this.settings.get('ignore').composite as Array<string>)]
+            ).catch(console.warn);
+        }
     }
 
     prepare_suggestions() {
@@ -326,15 +358,15 @@ class SpellChecker {
         if (original_mode_spec.indexOf("spellcheck_") == 0){
             return original_mode_spec;
         }
-        var me = this;
-        var new_mode_spec = 'spellcheck_' + original_mode_spec;
+        let me = this;
+        let new_mode_spec = 'spellcheck_' + original_mode_spec;
         CodeMirror.defineMode(new_mode_spec, (config:any) => {
-            var spellchecker_overlay = {
+            let spellchecker_overlay = {
                 name: new_mode_spec,
                 token: function (stream:any, state:any) {
                     if (stream.eatWhile(me.rx_word_char)) {
-                        var word = stream.current().replace(/(^')|('$)/g, '');
-                        if (!word.match(/^\d+$/) && (me.dictionary !== undefined) && !me.dictionary.check(word)) {
+                        let word = stream.current().replace(/(^')|('$)/g, '');
+                        if (!word.match(/^\d+$/) && (me.dictionary !== undefined) && !me.dictionary.check(word) && !me.ignored_tokens.has(word)) {
                             return 'spell-error';
                         }
                     }
@@ -346,6 +378,18 @@ class SpellChecker {
                 CodeMirror.getMode(config, original_mode_spec), spellchecker_overlay, true);
         });
         return new_mode_spec;
+    }
+
+    refresh_state() {
+        // update the active cell (if any)
+        if (this.tracker.activeCell != null) {
+            this.setup_cell_editor(this.tracker.activeCell);
+        }
+
+        // update the current file editor (if any)
+        if (this.editor_tracker.currentWidget != null) {
+            this.setup_file_editor(this.editor_tracker.currentWidget.content);
+        }
     }
 
     choose_language() {
@@ -360,16 +404,7 @@ class SpellChecker {
                 this.language = languages.filter(l => l.name == value.value)[0];
                 this.load_dictionary().then(() => {
                     this.status_widget.update();
-
-                    // update the active cell (if any)
-                    if (this.tracker.activeCell != null) {
-                        this.setup_cell_editor(this.tracker.activeCell);
-                    }
-
-                    // update the current file editor (if any)
-                    if (this.editor_tracker.currentWidget != null) {
-                        this.setup_file_editor(this.editor_tracker.currentWidget.content);
-                    }
+                    this.refresh_state()
                 });
             }
         });
@@ -387,7 +422,6 @@ class SpellChecker {
               item: this.status_widget
           }
         )
-
     }
 }
 
@@ -395,9 +429,9 @@ class SpellChecker {
 /**
  * Activate extension
  */
-function activate(app: JupyterFrontEnd, tracker: INotebookTracker, palette: ICommandPalette, editor_tracker: IEditorTracker, status_bar: IStatusBar) {
+function activate(app: JupyterFrontEnd, tracker: INotebookTracker, palette: ICommandPalette, editor_tracker: IEditorTracker, status_bar: IStatusBar, setting_registry: ISettingRegistry) {
     console.log('Attempting to load spellchecker');
-    const sp = new SpellChecker(app, tracker, palette, editor_tracker, status_bar);
+    const sp = new SpellChecker(app, tracker, palette, editor_tracker, status_bar, setting_registry);
     console.log("Spellchecker Loaded ", sp);
 }
 
@@ -406,9 +440,9 @@ function activate(app: JupyterFrontEnd, tracker: INotebookTracker, palette: ICom
  * Initialization data for the jupyterlab_spellchecker extension.
  */
 const extension: JupyterFrontEndPlugin<void> = {
-    id: 'jupyterlab_spellchecker',
+    id: '@ijmbarr/jupyterlab_spellchecker:plugin',
     autoStart: true,
-    requires: [INotebookTracker, ICommandPalette, IEditorTracker, IStatusBar],
+    requires: [INotebookTracker, ICommandPalette, IEditorTracker, IStatusBar, ISettingRegistry],
     activate: activate
 };
 

--- a/style/icons/ic-baseline-spellcheck.svg
+++ b/style/icons/ic-baseline-spellcheck.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" viewBox="0 0 24 24">
-  <g class="jp-icon3" fill="#616161" shape-rendering="geometricPrecision">
+  <g class="jp-icon3 jp-icon-selectable" fill="#616161" shape-rendering="geometricPrecision">
     <path d="M12.45 16h2.09L9.43 3H7.57L2.46 16h2.09l1.12-3h5.64l1.14 3zm-6.02-5L8.5 5.48L10.57 11H6.43zm15.16.59l-8.09 8.09L9.83 16l-1.41 1.41l5.09 5.09L23 13l-1.41-1.41z"/>
   </g>
 </svg>


### PR DESCRIPTION
![ignore](https://user-images.githubusercontent.com/5832902/89849819-3eda9d00-db81-11ea-8433-dc38e07b075b.gif)

For now, it is just a manually checked set. Ideally, we would be able to add it to the dictionary on the fly, so that we get suggestions on the ignored words (e.g. `JupiterLab → JupyterLab`), however Typo.js does not seem to be capable of that.

Given that Typo.js is also quite slow with suggestions, it might be worth considering an alternative implementation:
-  Atom's [spellchecker](https://www.npmjs.com/package/spellchecker) looks promising, but it might require node environment (so would not be an option).
- [hunspell-asm](https://www.npmjs.com/package/hunspell-asm) appears even better - especially given the option of merging multiple directories (which would allow to load basic English + medical English - would be a dream feature for me!).

I also improved some corner-cases for suggestions (nothing that would be noticed by the user, just exceptions being thrown without proper handling) - see the first commit.