### PR TITLE
Relax apputils pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^2.2.1",
-    "@jupyterlab/apputils": "2.2.2",
+    "@jupyterlab/apputils": "^2.2.2",
     "@jupyterlab/cells": "^2.2.2",
     "@jupyterlab/codemirror": "^2.2.1",
     "@jupyterlab/fileeditor": "^2.2.1",


### PR DESCRIPTION
The current pin prevents installing the new version of extension in JupyterLab != 2.2.2:

```
"@ijmbarr/jupyterlab_spellchecker@0.1.9" is not compatible with the current JupyterLab
JupyterLab           Extension      Package
>=2.2.4 <2.3.0       2.2.2          @jupyterlab/apputils
See the log file for details:  /tmp/jupyterlab-debug-x9jyuji7.log
```

Instead, it should require versions compatible with 2.2.2. Probably my fault, sorry about that!