### PR TITLE
Improve contrast for dark themes

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -4,4 +4,5 @@
 
 body[data-jp-theme-light='false'] .CodeMirror .cm-spell-error:not(.cm-url):not(.cm-tag):not(.cm-word) {
   background: rgba(255, 0, 0, .35);
+  text-shadow: 0 0 5px black;
 }

--- a/style/index.css
+++ b/style/index.css
@@ -1,3 +1,7 @@
 .CodeMirror .cm-spell-error:not(.cm-url):not(.cm-tag):not(.cm-word) {
-	 background: rgba(255, 0, 0, .15);
+  background: rgba(255, 0, 0, .15);
+}
+
+body[data-jp-theme-light='false'] .CodeMirror .cm-spell-error:not(.cm-url):not(.cm-tag):not(.cm-word) {
+  background: rgba(255, 0, 0, .35);
 }


### PR DESCRIPTION
Fixes #41

File editor before:

![Screenshot from 2021-02-08 21-03-39](https://user-images.githubusercontent.com/5832902/107281408-8b7c3380-6a51-11eb-8747-d7b0bdf551f0.png)

File editor after:

![Screenshot from 2021-02-08 21-06-47](https://user-images.githubusercontent.com/5832902/107281445-98992280-6a51-11eb-8350-72e99ba20d78.png)

Inactive cell before:

![Screenshot from 2021-02-08 21-08-23](https://user-images.githubusercontent.com/5832902/107281663-d7c77380-6a51-11eb-8a98-09e66f408b8a.png)

Inactive cell after:

![Screenshot from 2021-02-08 21-07-58](https://user-images.githubusercontent.com/5832902/107281685-dd24be00-6a51-11eb-9ef5-823ccd9d5b1e.png)

Disclaimer: I do not see all the colors and it is just ok for me now (but the contrast could be even stronger). If I overdid this please reduce accordingly to your liking.